### PR TITLE
Feature 871 (#873)

### DIFF
--- a/jme3-lwjgl3/build.gradle
+++ b/jme3-lwjgl3/build.gradle
@@ -2,7 +2,7 @@ if (!hasProperty('mainClass')) {
     ext.mainClass = ''
 }
 
-def lwjglVersion = '3.1.5'
+def lwjglVersion = '3.1.6'
 
 sourceCompatibility = '1.8'
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwKeyInput.java
@@ -32,17 +32,16 @@
 
 package com.jme3.input.lwjgl;
 
-import static org.lwjgl.glfw.GLFW.*;
 import com.jme3.input.KeyInput;
 import com.jme3.input.RawInputListener;
 import com.jme3.input.event.KeyInputEvent;
 import com.jme3.system.lwjgl.LwjglWindow;
-import org.lwjgl.glfw.GLFWCharCallback;
-import org.lwjgl.glfw.GLFWKeyCallback;
-
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.logging.Logger;
+import static org.lwjgl.glfw.GLFW.*;
+import org.lwjgl.glfw.GLFWCharCallback;
+import org.lwjgl.glfw.GLFWKeyCallback;
 
 /**
  * The LWJGL implementation of {@link KeyInput}.
@@ -54,7 +53,7 @@ public class GlfwKeyInput implements KeyInput {
     /**
      * The queue of key events.
      */
-    private final Queue<KeyInputEvent> keyInputEvents = new LinkedList<>();
+    private final Queue<KeyInputEvent> keyInputEvents = new ArrayDeque<>();
 
     /**
      * The LWJGL context.

--- a/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwMouseInput.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/input/lwjgl/GlfwMouseInput.java
@@ -31,7 +31,6 @@
  */
 package com.jme3.input.lwjgl;
 
-import static org.lwjgl.glfw.GLFW.*;
 import com.jme3.cursors.plugins.JmeCursor;
 import com.jme3.input.MouseInput;
 import com.jme3.input.RawInputListener;
@@ -39,17 +38,17 @@ import com.jme3.input.event.MouseButtonEvent;
 import com.jme3.input.event.MouseMotionEvent;
 import com.jme3.system.lwjgl.LwjglWindow;
 import com.jme3.util.BufferUtils;
-import org.lwjgl.glfw.*;
-import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.MemoryUtil;
-
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.util.ArrayDeque;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.logging.Logger;
+import org.lwjgl.glfw.*;
+import static org.lwjgl.glfw.GLFW.*;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 
 /**
  * Captures mouse input using GLFW callbacks. It then temporarily stores these
@@ -110,8 +109,8 @@ public class GlfwMouseInput implements MouseInput {
 
     private final Map<JmeCursor, long[]> jmeToGlfwCursorMap = new HashMap<>();
 
-    private final Queue<MouseMotionEvent> mouseMotionEvents = new LinkedList<>();
-    private final Queue<MouseButtonEvent> mouseButtonEvents = new LinkedList<>();
+    private final Queue<MouseMotionEvent> mouseMotionEvents = new ArrayDeque<>();
+    private final Queue<MouseButtonEvent> mouseButtonEvents = new ArrayDeque<>();
 
     private final LwjglWindow context;
 

--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -32,9 +32,6 @@
 
 package com.jme3.system.lwjgl;
 
-import static org.lwjgl.glfw.GLFW.*;
-import static org.lwjgl.opengl.GL11.GL_FALSE;
-import static org.lwjgl.system.MemoryUtil.NULL;
 import com.jme3.input.JoyInput;
 import com.jme3.input.KeyInput;
 import com.jme3.input.MouseInput;
@@ -47,9 +44,6 @@ import com.jme3.system.JmeContext;
 import com.jme3.system.JmeSystem;
 import com.jme3.system.NanoTimer;
 import com.jme3.util.BufferUtils;
-import org.lwjgl.Version;
-import org.lwjgl.glfw.*;
-
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
@@ -59,6 +53,11 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.lwjgl.Version;
+import org.lwjgl.glfw.*;
+import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.opengl.GL11.GL_FALSE;
+import static org.lwjgl.system.MemoryUtil.NULL;
 
 /**
  * A wrapper class over the GLFW framework in LWJGL 3.
@@ -383,6 +382,10 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
             }
 
             if (errorCallback != null) {
+
+                // We need to specifically set this to null as we might set a new callback before we reinit GLFW
+                glfwSetErrorCallback(null);
+
                 errorCallback.close();
                 errorCallback = null;
             }
@@ -401,6 +404,8 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
                 glfwDestroyWindow(window);
                 window = NULL;
             }
+
+            glfwTerminate();
         } catch (final Exception ex) {
             listener.handleError("Failed to destroy context", ex);
         }
@@ -548,7 +553,6 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
     /**
      * De-initialize in the OpenGL thread.
      */
-
     protected void deinitInThread() {
         listener.destroy();
 


### PR DESCRIPTION
* Update LWJGL to 3.1.6

* Change LinkedLists to ArrayDeques

* Call glfwTerminate & set NULL error callback on destroy

fixes crash when context is re-created